### PR TITLE
Snapshot pruning lazy load fix

### DIFF
--- a/taskobra/orm/snapshot.py
+++ b/taskobra/orm/snapshot.py
@@ -46,7 +46,6 @@ class Snapshot(ORMBase):
         return (
             self.timestamp and
             other.timestamp and
-            # self.sample_exponent > other.sample_exponent and
             (
                 self.t_start  < other.timestamp <= self.t_end or
                 other.t_start < self.timestamp  <= other.t_end
@@ -98,7 +97,6 @@ class Snapshot(ORMBase):
         pruned = Snapshot(sample_count=0, sample_exponent=1)
 
         for snapshot in snapshots:
-            # [metric for metric in snapshot.metrics]
             try:
                 pruned = pruned.merge(snapshot)
                 yield snapshot, None

--- a/taskobra/orm/snapshot.py
+++ b/taskobra/orm/snapshot.py
@@ -20,7 +20,7 @@ class Snapshot(ORMBase):
     __tablename__ = "Snapshot"
     unique_id = Column(Integer, primary_key=True)
     timestamp = Column(DateTime)
-    metrics = relationship("Metric", secondary=snapshot_metric_table)
+    metrics = relationship("Metric", secondary=snapshot_metric_table, lazy="joined")
     sample_count = Column(Integer, default=1)
     sample_rate = Column(Float, default=1.0)
     sample_base = Column(Float, default=2.0)
@@ -98,6 +98,7 @@ class Snapshot(ORMBase):
         pruned = Snapshot(sample_count=0, sample_exponent=1)
 
         for snapshot in snapshots:
+            # [metric for metric in snapshot.metrics]
             try:
                 pruned = pruned.merge(snapshot)
                 yield snapshot, None

--- a/taskobra/web/views/api.py
+++ b/taskobra/web/views/api.py
@@ -64,11 +64,8 @@ def metrics_storage():
 
 @blueprint.route('/prune')
 def prune():
-    for old, new in Snapshot.prune(db_session.query(Snapshot)):
-        if old:
-            db_session.delete(old)
-        if new:
-            db_session.add(new)
-        if old or new:
-            db_session.commit()
+    for old, new in Snapshot.prune(db_session.query(Snapshot).order_by(Snapshot.timestamp.desc())):
+        if old: db_session.delete(old)
+        if new: db_session.add(new)
+    db_session.commit()
     return jsonify({})


### PR DESCRIPTION
Fixed a bug where Snapshot pruning wasn't resulting in the right thing if the session wasn't committed until after pruning was completed.  This was because metrics weren't being eagerly loaded by snapshot instances.